### PR TITLE
A non-static method (isJson) should not be called statically

### DIFF
--- a/src/Aspose/Words/APIClient.php
+++ b/src/Aspose/Words/APIClient.php
@@ -325,7 +325,7 @@ class APIClient {
         return $instance;
     }
 
-    public function isJson($string) {
+    public static function isJson($string) {
         return is_string($string) && is_object(json_decode($string)) && (json_last_error() == JSON_ERROR_NONE) ? true : false;
     }
 


### PR DESCRIPTION
The non-static method `isJson` is being called statically on line 272 which results in a error on PHP7+
```PHP
if (self::isJson($object)) {
    $object = json_decode($object);
} else {
    return $object;
}
```